### PR TITLE
chore: bootstrap repo (docs, ADRs, CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: go test + fmt
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Go fmt check
+        run: |
+          OUT=$(gofmt -l .)
+          if [ -n "$OUT" ]; then
+            echo "gofmt issues found in:"
+            echo "$OUT"
+            exit 1
+          fi
+
+      - name: Go test
+        run: go test ./...

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,20 @@ go.work.sum
 
 # env file
 .env
+.env.*
+!.env.example
 
 # Editor/IDE
-# .idea/
-# .vscode/
+.idea/
+.vscode/
+
+# OS files
+.DS_Store
+
+# Logs
+*.log
+
+# Common build/output dirs (optional but safe)
+bin/
+dist/
+tmp/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,122 @@
 # go-url-shortener
-Monolithic Go URL Shortener service (REST, JWT auth, role-based access, PostgreSQL, Docker, tests) — Quera Bootcamp project.
+
+A **production-like, monolithic URL shortener** built with **Go (Fiber)** and **PostgreSQL (GORM)**.  
+It provides authenticated APIs for users/admins and a public redirect endpoint for visitors, with minimum analytics (click count).
+
+---
+
+## What this service does (quick overview)
+Marketing URLs are often long and error-prone to share. This service:
+- lets authenticated users create short links for long URLs
+- redirects public visitors from `/:shortCode` to the original URL
+- tracks minimum analytics (**click_count**)
+- provides admin endpoints to manage users/URLs
+
+### Roles
+- **User (authenticated):** create short URLs, list own URLs, view basic stats
+- **Visitor (public):** open a short URL and get redirected (no login required)
+- **Admin (authenticated, role=admin):** manage users and URLs across the system
+
+---
+
+## Tech stack
+- **Language:** Go
+- **HTTP framework:** Fiber ([ADR-0001](docs/adr/0001-use-fiber.md))
+- **Database:** PostgreSQL ([ADR-0002](docs/adr/0002-use-postgres-gorm.md))
+- **ORM:** GORM ([ADR-0002](docs/adr/0002-use-postgres-gorm.md))
+- **Migrations:** golang-migrate/migrate
+- **Auth:** JWT access tokens (MVP) ([ADR-0003](docs/adr/0003-auth-jwt-access-token.md))
+- **Password hashing:** Argon2id ([ADR-0004](docs/adr/0004-password-hashing-argon2.md))
+- **Logging:** zerolog ([ADR-0008](docs/adr/0008-logging-zerolog.md))
+
+---
+
+## MVP product rules (locked decisions)
+- **Redirect:** `302` by default ([ADR-0007](docs/adr/0007-redirect-policy.md))
+- **Short code:** random Base62, length **7**, uniqueness enforced by DB unique index + retry on collision ([ADR-0005](docs/adr/0005-shortcode-strategy.md))
+- **URL validation:** allow only `http/https`, must be parseable with a host (optional hardening: block localhost/private IPs)
+- **Analytics:** minimum `click_count` (atomic increment during redirect)
+
+---
+
+## API summary (v0.1)
+- Base path: `/api/v1`
+- Public redirect: `/:shortCode` (no `/api/v1` prefix)
+
+### Auth
+- `POST /api/v1/auth/register`
+- `POST /api/v1/auth/login`
+
+### User URLs (JWT required)
+- `POST /api/v1/urls`
+- `GET  /api/v1/urls`
+- `GET  /api/v1/urls/:id` (optional)
+
+### Admin (JWT + role=admin)
+- `GET  /api/v1/admin/users`
+- `GET  /api/v1/admin/urls`
+- `PATCH /api/v1/admin/urls/:id/disable`
+
+Full contract + examples: **[docs/api.md](docs/api.md)**
+
+---
+
+## Repository standards (Docs-as-Code)
+This repository is the **source of truth**:
+- Architecture overview: **[docs/overview.md](docs/overview.md)**
+- API contract: **[docs/api.md](docs/api.md)**
+- Runbook (run/test/debug): **[docs/runbook.md](docs/runbook.md)**
+- Decisions (ADR): **[docs/adr/](docs/adr/)**
+- Meeting notes: **[docs/meetings/](docs/meetings/)**
+
+**Telegram policy:** Telegram is used only for quick coordination and posting links to PRs/Issues/ADRs/meeting notes.
+
+---
+
+## Quick start (development)
+> Requires Docker + Docker Compose.
+
+1) Create env file:
+```bash
+cp .env.example .env
+````
+
+2. Start services:
+
+```bash
+docker compose up --build
+```
+
+3. Run tests:
+
+```bash
+go test ./...
+```
+
+More details (migrations, troubleshooting): **[docs/runbook.md](docs/runbook.md)**
+
+---
+
+## Project structure (high level)
+
+* `cmd/server`: application entrypoint
+* `internal/http`: Fiber routes/handlers/middleware/DTOs + centralized error handling
+* `internal/service`: business logic (use-cases)
+* `internal/repository`: database access (Postgres/GORM)
+* `migrations/`: SQL migrations
+
+---
+
+## Contribution workflow
+
+* `main` is protected → PR required
+* 1 approval required
+* CI must pass before merge
+* Keep PRs small and scoped; update docs/ADR when introducing decisions
+
+---
+
+## License
+
+See [LICENSE](LICENSE)
+

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/docs/adr/0000-template.md
+++ b/docs/adr/0000-template.md
@@ -1,0 +1,52 @@
+# ADR-0000: <Title>
+**Status:** Proposed | Accepted | Deprecated  
+**Date:** YYYY-MM-DD  
+**Owner:** <Name or Team>
+
+## Context
+Explain the problem or requirement that forces a decision.
+- What are we building?
+- What constraints do we have (time, team size, spec requirements)?
+- What pain does this decision solve?
+
+## Decision
+State the decision clearly and unambiguously.
+- What did we choose?
+- What is the scope (MVP vs future)?
+- Any parameters that must be fixed (e.g., redirect=302, code length=7)?
+
+## Decision Drivers
+List the main reasons why this decision was made (3–7 bullets).
+Examples:
+- Delivery time (2-week scope)
+- Simplicity/maintainability
+- Security baseline
+- Operational ease (Docker/CI)
+- Team familiarity
+
+## Alternatives Considered
+List alternatives you seriously considered and why they were not chosen.
+Format suggestion:
+- **Option A** — short pros/cons
+- **Option B** — short pros/cons
+
+## Consequences
+Explain what this decision implies going forward.
+- What will we implement because of this?
+- What do we lose / risks / trade-offs?
+- What future changes become easier/harder?
+
+## Implementation Notes (optional)
+Practical notes that help implementation but are not part of the decision.
+Examples:
+- Exact config keys / defaults
+- File/module boundaries
+- Retry policy details
+- DB constraints/indexes
+
+## References
+Link to evidence and traceability:
+- Related meeting note: `docs/meetings/YYYY-MM-DD-....md`
+- Related issue(s): `#123, #124`
+- Related PR(s): `#45`
+- Related docs: `docs/api.md`, `docs/overview.md`

--- a/docs/adr/0001-use-fiber.md
+++ b/docs/adr/0001-use-fiber.md
@@ -1,0 +1,24 @@
+# ADR-0001: Use Fiber as the HTTP framework
+**Status:** Accepted  
+**Date:** 2026-01-07  
+**Owner:** Team
+
+## Context
+We need a Go HTTP framework to implement REST APIs with routing, middleware, and consistent error handling.
+The project allows Fiber/Gin/Echo. Team familiarity and speed matter due to the 2-week timeline.
+
+## Decision
+We will use **Fiber** as the HTTP framework.
+
+## Alternatives considered
+- **Gin**: very common and stable, good ecosystem
+- **Echo**: solid framework with clean APIs
+
+## Consequences
+- All HTTP routing/middleware will be implemented using Fiber.
+- Handlers will remain thin and delegate business rules to service layer (clean layering).
+- Fiber-specific code must be limited to the HTTP layer (`internal/http/...`) to keep business logic testable.
+
+## Notes
+- We will implement a centralized Fiber error handler to enforce a consistent error response format.
+

--- a/docs/adr/0002-use-postgres-gorm.md
+++ b/docs/adr/0002-use-postgres-gorm.md
@@ -1,0 +1,27 @@
+# ADR-0002: Use PostgreSQL + GORM for persistence
+**Status:** Accepted  
+**Date:** 2026-01-07  
+**Owner:** Team
+
+## Context
+We need persistent storage for users, URLs, and analytics (minimum click count).
+The project recommends PostgreSQL and requires an ORM.
+
+## Decision
+We will use:
+- **PostgreSQL** as the database
+- **GORM** as the ORM
+
+## Alternatives considered
+- **MongoDB**: allowed, but relational constraints (unique short_code, ownership) are simpler in Postgres
+- **Ent**: strong typed ORM but more setup overhead for the 2-week timeline
+- **sqlc**: excellent for SQL-first, but requires more manual query/structure work (still acceptable, but team chose GORM)
+
+## Consequences
+- Schema will be defined via SQL migrations, while runtime access is via GORM models.
+- We will enforce key integrity at DB level (e.g., unique index on `short_code`, unique email).
+- Repository layer will wrap GORM and expose interfaces to services.
+
+## Notes
+- Minimum tables: `users`, `urls` (+ optional fields for admin/disable).
+

--- a/docs/adr/0003-auth-jwt-access-token.md
+++ b/docs/adr/0003-auth-jwt-access-token.md
@@ -1,0 +1,32 @@
+# ADR-0003: Use JWT access tokens for authentication (MVP)
+**Status:** Accepted  
+**Date:** 2026-01-07  
+**Owner:** Team
+
+## Context
+We need API authentication and role-based access (user vs admin).
+The project allows JWT/PASETO/JWE/TLS-based approaches.
+We want a simple, industry-standard approach within 2 weeks.
+
+## Decision
+We will use **JWT access tokens** for authentication in MVP.
+
+### Token strategy (MVP)
+- **Access token only** (no refresh token in MVP)
+- Tokens are sent using: `Authorization: Bearer <token>`
+
+### Claims (minimum)
+- `sub` = user_id
+- `role` = user/admin
+- `exp` = expiration timestamp
+
+## Alternatives considered
+- **PASETO**: safer by design; less common in many ecosystems
+- **JWE**: encrypted tokens; more complexity than needed for MVP
+- **Sessions/cookies**: not ideal for pure API service in this bootcamp scope
+
+## Consequences
+- Protected endpoints require JWT middleware.
+- RBAC is enforced using `role` claim checked in middleware for admin routes.
+- Token expiration requires re-login once expired (acceptable for MVP).
+

--- a/docs/adr/0004-password-hashing-argon2.md
+++ b/docs/adr/0004-password-hashing-argon2.md
@@ -1,0 +1,20 @@
+# ADR-0004: Use Argon2 for password hashing
+**Status:** Accepted  
+**Date:** 2026-01-07  
+**Owner:** Team
+
+## Context
+Passwords must be stored securely. Plain-text passwords are forbidden.
+We need a modern password hashing algorithm suitable for production-like systems.
+
+## Decision
+We will use **Argon2id** for password hashing and verification.
+
+## Alternatives considered
+- **bcrypt**: widely used and acceptable; generally slower to tune and less modern than Argon2id
+
+## Consequences
+- Only password hashes are stored in DB (`password_hash`).
+- Password verification uses constant-time comparison.
+- We must standardize parameters (time/memory/parallelism) and keep them configurable if needed.
+

--- a/docs/adr/0005-shortcode-strategy.md
+++ b/docs/adr/0005-shortcode-strategy.md
@@ -1,0 +1,28 @@
+# ADR-0005: Short code strategy (Base62 random, length 7)
+**Status:** Accepted  
+**Date:** 2026-01-07  
+**Owner:** Team
+
+## Context
+Short links must map `short_code -> original_url`.
+Short codes must be unique and safe under concurrent requests.
+We want a simple approach that scales and avoids predictability issues.
+
+## Decision
+We will generate short codes as:
+- **Random Base62**
+- **Fixed length: 7 characters**
+- Uniqueness enforced by **DB unique index** on `urls.short_code`
+
+### Collision handling
+- On DB unique constraint violation during insert, retry code generation up to **5 times**.
+- If still failing (extremely unlikely), return a 500 error with a clear error code.
+
+## Alternatives considered
+- **Sequential ID + Base62 encoding**: easier uniqueness, but predictable (enumeration risk) unless additional hardening is added
+- **Hash(original_url)**: deterministic but may leak information; also collisions require careful handling
+
+## Consequences
+- We must add a unique index/constraint on `short_code`.
+- Insert logic must handle duplicate errors and retry.
+- Length 7 is a balance of usability and collision probability for MVP scale.

--- a/docs/adr/0006-error-format.md
+++ b/docs/adr/0006-error-format.md
@@ -1,0 +1,38 @@
+# ADR-0006: Standard API error format and HTTP status codes
+**Status:** Accepted  
+**Date:** 2026-01-07  
+**Owner:** Team
+
+## Context
+To keep clients/tests simple, API error responses must be consistent across endpoints.
+The project requires standard HTTP status codes and unified error handling.
+
+## Decision
+All API errors will use this JSON structure:
+
+```json
+{
+  "error": {
+    "code": "STRING_CODE",
+    "message": "Human readable message"
+  }
+}
+```
+
+## Status code policy (minimum)
+
+- `400` Bad Request: validation errors, invalid URL, malformed input
+- `401` Unauthorized: missing/invalid token
+- `403` Forbidden: valid token but insufficient role/permissions
+- `404` Not Found: short code not found / resource not found
+- `409` Conflict: uniqueness conflicts (if exposed; otherwise internal retry)
+- `500` Internal Server Error: unexpected errors
+
+## Alternatives considered
+
+- Ad-hoc error responses per endpoint: rejected due to inconsistency and harder testing
+
+## Consequences
+
+- We must implement a centralized Fiber error handler (or helper) to enforce this format.
+- Services should return domain errors with codes mapped to HTTP status codes in handlers.

--- a/docs/adr/0007-redirect-policy.md
+++ b/docs/adr/0007-redirect-policy.md
@@ -1,0 +1,18 @@
+# ADR-0007: Redirect policy (302 for MVP)
+**Status:** Accepted  
+**Date:** 2026-01-07  
+**Owner:** Team
+
+## Context
+The redirect endpoint `GET /:shortCode` must redirect to the original URL.
+We must choose 301 (permanent) vs 302 (temporary).
+
+## Decision
+For MVP, we will use **302 Temporary Redirect**.
+
+## Alternatives considered
+- **301 Permanent Redirect**: can be cached aggressively by clients/browsers and makes future changes harder
+
+## Consequences
+- 302 keeps flexibility if we need to change original URLs or add rules later.
+- Redirect behavior must be documented in API docs and README.

--- a/docs/adr/0008-logging-zerolog.md
+++ b/docs/adr/0008-logging-zerolog.md
@@ -1,0 +1,27 @@
+# ADR-0008: Structured logging with zerolog (+ request_id)
+**Status:** Accepted  
+**Date:** 2026-01-07  
+**Owner:** Team
+
+## Context
+We need production-like logging for debugging and traceability.
+Logs should be structured (machine-readable) and consistent across requests.
+
+## Decision
+We will use **zerolog** for structured JSON logging.
+
+### Minimum logging fields
+- `request_id`
+- `method`, `path`
+- `status`
+- `latency_ms`
+- `user_id` (when available)
+- `error` details (when applicable)
+
+## Alternatives considered
+- **zap**: strong option but slightly heavier for setup
+- standard `log` package: not structured, less suitable for production-like observability
+
+## Consequences
+- Implement request-id middleware and log middleware early.
+- Log format will be JSON for easy filtering in containers/CI logs.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,304 @@
+# API Contract — v0.1
+
+## Base URLs & routing
+
+- **API endpoints prefix:** `/api/v1`
+- **Public redirect (no API prefix):** `/:shortCode`
+
+All responses are **JSON** unless specified otherwise (the public redirect returns an HTTP redirect).
+
+---
+
+## Authentication
+
+MVP uses **JWT access token**.
+
+### Request header
+- `Authorization: Bearer <token>`
+
+### RBAC
+- **Admin endpoints** require `role=admin` in JWT claims.
+
+See:
+- [ADR-0003](./adr/0003-auth-jwt-access-token.md)
+
+---
+
+## Standard error format
+
+All API errors follow this shape:
+
+```json
+{
+  "error": {
+    "code": "STRING_CODE",
+    "message": "Human readable message"
+  }
+}
+```
+
+### Status codes (minimum)
+
+- `400` — invalid input / validation error
+- `401` — missing or invalid token
+- `403` — forbidden (not admin / not allowed)
+- `404` — not found
+- `409` — conflict (optional; for unique conflicts if exposed)
+- `500` — internal error
+
+See:
+- ADR-0006
+
+---
+
+## Common validation rules
+
+### URL validation (MVP)
+
+- allowed schemes: `http`, `https`
+- must be parseable and have a valid host
+- max length: **2048** (or **4096** if needed)
+
+Optional hardening (if implemented):
+- block localhost/private IP targets to reduce SSRF risk
+
+---
+
+## Endpoints
+
+### 1) Auth
+
+#### POST `/api/v1/auth/register`
+
+Create a new user.
+
+**Request**
+```json
+{
+  "email": "user@example.com",
+  "password": "StrongPassword123!"
+}
+```
+
+**Response (201)**
+```json
+{
+  "id": "user_id",
+  "email": "user@example.com",
+  "role": "user"
+}
+```
+
+**Errors**
+- `400` — invalid email/password format
+- `409` — email already exists (optional)
+
+---
+
+#### POST `/api/v1/auth/login`
+
+Login and receive a JWT access token.
+
+**Request**
+```json
+{
+  "email": "user@example.com",
+  "password": "StrongPassword123!"
+}
+```
+
+**Response (200)**
+```json
+{
+  "access_token": "JWT_TOKEN",
+  "token_type": "Bearer",
+  "expires_in": 3600
+}
+```
+
+**Errors**
+- `400` — invalid input
+- `401` — wrong credentials
+
+---
+
+### 2) User URLs (JWT required)
+
+#### POST `/api/v1/urls`
+
+Create a short URL for the authenticated user.
+
+**Request**
+```json
+{
+  "original_url": "https://example.com/landing?utm_source=telegram&utm_campaign=w1"
+}
+```
+
+**Response (201)**
+```json
+{
+  "id": "url_id",
+  "original_url": "https://example.com/landing?utm_source=telegram&utm_campaign=w1",
+  "short_code": "aB7xQp1",
+  "short_url": "https://<your-domain>/aB7xQp1",
+  "click_count": 0,
+  "is_disabled": false,
+  "created_at": "2026-01-07T17:30:00Z"
+}
+```
+
+**Notes**
+- `short_code` generation: **random Base62 length 7**, uniqueness enforced by **DB unique index**.  
+  See: ADR-0005
+
+**Errors**
+- `400` — invalid URL
+- `401` — missing/invalid token
+- `500` — could not generate unique code after retries (rare)
+
+---
+
+#### GET `/api/v1/urls`
+
+List URLs owned by the authenticated user.
+
+**Response (200)**
+```json
+{
+  "items": [
+    {
+      "id": "url_id",
+      "original_url": "https://example.com/landing?utm_source=telegram&utm_campaign=w1",
+      "short_code": "aB7xQp1",
+      "short_url": "https://<your-domain>/aB7xQp1",
+      "click_count": 12,
+      "is_disabled": false,
+      "created_at": "2026-01-07T17:30:00Z"
+    }
+  ]
+}
+```
+
+**Pagination (optional but recommended)**
+If implemented:
+
+- Query: `?limit=20&offset=0`
+- Response may include: `limit`, `offset`, `total`
+
+**Errors**
+- `401` — missing/invalid token
+
+---
+
+#### GET `/api/v1/urls/:id` (optional)
+
+Get details for a URL owned by the authenticated user.
+
+**Response (200)**  
+Same shape as the **Create URL** response.
+
+**Errors**
+- `401` — missing/invalid token
+- `403` — not owner
+- `404` — not found
+
+---
+
+### 3) Admin endpoints (JWT + role=admin)
+
+#### GET `/api/v1/admin/users`
+
+List users.
+
+**Response (200)**
+```json
+{
+  "items": [
+    {
+      "id": "user_id",
+      "email": "user@example.com",
+      "role": "user",
+      "created_at": "2026-01-07T17:00:00Z"
+    }
+  ]
+}
+```
+
+**Errors**
+- `401` — missing/invalid token
+- `403` — not admin
+
+---
+
+#### GET `/api/v1/admin/urls`
+
+List URLs across the system.
+
+**Response (200)**
+```json
+{
+  "items": [
+    {
+      "id": "url_id",
+      "owner_id": "user_id",
+      "original_url": "https://example.com",
+      "short_code": "aB7xQp1",
+      "click_count": 12,
+      "is_disabled": false,
+      "created_at": "2026-01-07T17:30:00Z"
+    }
+  ]
+}
+```
+
+**Errors**
+- `401` — missing/invalid token
+- `403` — not admin
+
+---
+
+#### PATCH `/api/v1/admin/urls/:id/disable`
+
+Disable a URL (minimum admin action in MVP).
+
+**Request**
+```json
+{
+  "is_disabled": true
+}
+```
+
+**Response (200)**
+```json
+{
+  "id": "url_id",
+  "is_disabled": true
+}
+```
+
+**Errors**
+- `401` — missing/invalid token
+- `403` — not admin
+- `404` — not found
+
+---
+
+### 4) Public redirect (no auth)
+
+#### GET `/:shortCode`
+
+Redirect to original URL (MVP uses **302**).
+
+**Behavior**
+- If exists and not disabled:
+    - increment `click_count` atomically
+    - respond **302** with `Location: <original_url>`
+- If not found or disabled:
+    - respond **404**
+
+See:
+- ADR-0007
+
+**Response**
+- `302` redirect (no JSON body required)

--- a/docs/meetings/2026-01-07-kickoff.md
+++ b/docs/meetings/2026-01-07-kickoff.md
@@ -1,0 +1,118 @@
+# Kickoff Meeting — Go URL Shortener (Quera Bootcamp)
+**Date:** 2026-01-07  
+**Time:** 17:00–18:00 (Europe/Madrid)  
+**Location:** Google Meet (link: <paste_link_here>)  
+**Notes owner:** Reza  
+**Channel:** Telegram (links-only announcements)
+
+---
+
+## Attendees
+- Reza
+- Parsa
+
+---
+
+## Goal (what we must leave with)
+- MVP scope + Definition of Done
+- Initial API contract direction
+- Tech stack decisions
+- Workflow (Docs-as-Code + GitHub Issues/PR)
+- Week 1 plan (owners + next actions)
+
+---
+
+## Problem statement (1-minute summary)
+Marketing URLs are often long and error-prone to share. We will build an internal URL shortener that:
+- lets authenticated users create short links
+- redirects public visitors to the original URL
+- tracks minimum analytics (click count)
+- provides admin controls for users/URLs
+
+---
+
+## Decisions (locked)
+### Tech stack
+- HTTP framework: **Fiber**
+- Database: **PostgreSQL**
+- ORM: **GORM**
+- Migrations: **golang-migrate/migrate**
+- Auth: **JWT (access token for MVP)**
+- Password hashing: **Argon2**
+- Logging: **zerolog**
+- Default branch: **main** (protected)
+
+> ADR links:
+- [ADR-0001: Use Fiber](../adr/0001-use-fiber.md)
+- [ADR-0002: Use PostgreSQL + GORM](../adr/0002-use-postgres-gorm.md)
+- [ADR-0003: JWT access tokens](../adr/0003-auth-jwt-access-token.md)
+- [ADR-0004: Argon2 password hashing](../adr/0004-password-hashing-argon2.md)
+- [ADR-0005: Short code strategy](../adr/0005-shortcode-strategy.md)
+- [ADR-0006: Error format](../adr/0006-error-format.md)
+- [ADR-0007: Redirect policy](../adr/0007-redirect-policy.md)
+- [ADR-0008: Logging](../adr/0008-logging-zerolog.md)
+
+### Product rules (MVP)
+- Redirect: **302**
+- Short code: **random Base62, length 7**, DB unique index on `short_code`, retry on collision (max 5)
+- URL validation: allow **http/https**, must be parseable with host (optional: block localhost/private IP)
+- Analytics: minimum **click_count**, increment must be atomic in DB
+
+---
+
+## MVP Scope (week-2 delivery)
+### Must-have
+- Auth: register/login + JWT middleware + RBAC (user/admin)
+- URLs: create short URL, list own URLs
+- Public redirect: `GET /:shortCode` with 302 + click_count++
+- Admin basics: list users, list URLs, disable URL (minimum 1 admin action)
+- Engineering: Docker dev/prod, tests (core+auth), docs (API+DB+run+test)
+
+### Non-goals (for MVP)
+- custom alias, expiration, QR, redis cache, rate limiting, detailed analytics table
+
+---
+
+## Definition of Done (MVP)
+- End-to-end flow works: register → login → shorten → redirect → click_count increments
+- Admin endpoints require role=admin (user gets 403)
+- Runs on clean machine via Docker
+- `go test ./...` passes
+- Docs allow a new developer to run + test without help
+
+---
+
+## Week 1 objective (end-of-week outcome)
+By end of Week 1 we should have:
+- Running skeleton + core end-to-end flow (auth + shorten + redirect + click_count)
+- Repo bootstrapped with CI + docs-as-code foundation
+- Initial GitHub issues created and assigned
+
+---
+
+## Action items (Week 1) — owners
+> These must be tracked as GitHub Issues. Add links after creating issues.
+
+### Reza
+- Bootstrap repo structure + docs-as-code + CI (PR #___ / Issue #___)
+- Create API Contract v0.1 (`docs/api.md`) + define error format (Issue #___)
+- Create initial ADRs + meeting notes in repo (Issue #___)
+
+### Parsa (API/HTTP)
+- Fiber setup + `/api/v1` routing + health endpoint (Issue #___)
+- Implement user URL endpoints: POST `/api/v1/urls`, GET `/api/v1/urls` (Issue #___)
+- Implement public redirect `GET /:shortCode` (Issue #___)
+
+### Mani (DB/Auth/DevOps)
+- Postgres + GORM integration + base migrations (Issue #___)
+- Implement auth: Argon2 hash + JWT login/register + auth middleware (Issue #___)
+- Docker compose (dev) + `.env.example` (Issue #___)
+
+---
+
+## Parking lot (decide later)
+- Rate limiting
+- Redis caching
+- Detailed analytics (url_visits table)
+- Metrics/observability
+- Refresh tokens

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,141 @@
+# Architecture Overview — go-url-shortener
+
+This project is a **monolithic, production-like URL shortener** built with Go (Fiber) + PostgreSQL (GORM).
+It provides authenticated APIs for users/admins and a public redirect endpoint for visitors.
+
+---
+
+## Goals (what we must deliver)
+- Authenticated users can **create** short URLs and **list** their own URLs.
+- Public visitors can open `GET /:shortCode` and be **redirected** to the original URL.
+- Minimum analytics: **click_count** increments on each redirect.
+- Admin can **manage** (at least list + disable) users/URLs.
+- Engineering quality: Docker (dev/prod), tests, docs-as-code, consistent error handling.
+
+## Non-goals (MVP)
+- Custom aliases, expiration, QR codes, detailed analytics (visits table), Redis cache, rate limiting, metrics dashboard.
+
+---
+
+## Roles (who uses the system)
+- **User (authenticated):** creates short URLs and views own data.
+- **Visitor (public):** opens short URLs; no login needed.
+- **Admin (authenticated, role=admin):** manages users and URLs.
+
+---
+
+## Key product rules (locked decisions)
+- Redirect: **302** (temporary)  
+  See: [ADR-0007](./adr/0007-redirect-policy.md)
+- Short code: **random Base62**, fixed length **7**, uniqueness enforced by DB unique index, retry on collision  
+  See: [ADR-0005](./adr/0005-shortcode-strategy.md)
+- Auth: **JWT access token (MVP)**, RBAC via role claim  
+  See: [ADR-0003](./adr/0003-auth-jwt-access-token.md)
+- Password hashing: **Argon2id**  
+  See: [ADR-0004](./adr/0004-password-hashing-argon2.md)
+- Logging: **zerolog**, structured JSON + request_id  
+  See: [ADR-0008](./adr/0008-logging-zerolog.md)
+- Error format: consistent JSON error structure across endpoints  
+  See: [ADR-0006](./adr/0006-error-format.md)
+
+---
+
+## High-level request flow
+
+### A) Create short URL (authenticated)
+Client
+→ Fiber router
+→ Auth middleware (JWT)
+→ Handler (HTTP parsing/validation)
+→ Service (business rules, short code generation)
+→ Repository (DB insert)
+→ Response (short URL + metadata)
+
+### B) Public redirect (no auth)
+Visitor
+→ `GET /:shortCode`
+→ Handler
+→ Service (lookup + check disabled)
+→ Repository:
+- fetch original_url
+- atomic increment click_count
+  → `302 Location: original_url`
+
+---
+
+## Code organization (clean layering)
+We keep Fiber-specific code in the HTTP layer and business logic in services:
+
+- **HTTP Layer (`internal/http/...`)**
+    - Routing, handlers/controllers, DTOs, middleware, centralized error handler.
+    - No business rules beyond basic request validation.
+
+- **Service Layer (`internal/service/...`)**
+    - Use-cases / business logic:
+        - validate URL rules (service-level)
+        - generate short code + retry policy
+        - RBAC checks for admin endpoints
+        - redirect behavior + analytics increment strategy
+
+- **Repository Layer (`internal/repository/...`)**
+    - DB access (Postgres/GORM).
+    - Must implement atomic operations (e.g., click_count increment).
+
+This separation keeps logic testable (unit tests can target services without Fiber).
+
+---
+
+## Persistence model (MVP)
+### users
+- id
+- email (unique)
+- password_hash
+- role: user/admin
+- created_at, updated_at
+
+### urls
+- id
+- owner_id (FK -> users.id)
+- original_url
+- short_code (unique)
+- click_count (default 0)
+- is_disabled (default false)
+- created_at, updated_at
+
+**DB guarantees**
+- Unique index on `urls.short_code`
+- Unique index on `users.email`
+- Atomic increment on click_count in redirect path
+
+---
+
+## Configuration & secrets
+- Use environment variables for configuration (Docker-friendly).
+- Never commit `.env` to the repo; commit `.env.example` only.
+- JWT secret and DB credentials must come from env.
+
+---
+
+## Observability (logging)
+- Structured logs with zerolog (JSON)
+- Include `request_id` on every request
+- Log method/path/status/latency and user_id when available
+
+---
+
+## Testing strategy
+- Unit tests: service-level business rules (no DB, repo mocked).
+- Integration tests: core E2E flows (auth → shorten → redirect → admin RBAC).
+
+---
+
+## Docs-as-Code workflow (source of truth)
+- Architecture & docs: `docs/`
+- Decisions: `docs/adr/`
+- Meeting notes: `docs/meetings/`
+- Telegram: links-only announcements (PR/Issue/ADR/meeting links)
+
+See also:
+- API contract: [docs/api.md](./api.md)
+- Runbook: [docs/runbook.md](./runbook.md)
+

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1,0 +1,153 @@
+# Runbook — Local Dev & Operations
+
+This runbook explains how to run, test, and troubleshoot the service locally.
+
+---
+
+## Prerequisites
+- Go (recommended: **1.22**)
+- Docker + Docker Compose
+- (Optional) Make
+
+---
+
+## Configuration
+
+We use environment variables. **Do not commit real secrets.**
+
+### Required env vars (example)
+
+Create `.env` from `.env.example`:
+
+- `APP_ENV=dev`
+- `APP_PORT=8080`
+- `DATABASE_URL=postgres://<user>:<pass>@db:5432/<db>?sslmode=disable`
+- `JWT_SECRET=<random_secret>`
+- `JWT_EXPIRES_IN_SECONDS=3600`
+
+> The exact keys should match the implementation in `internal/config`.
+
+---
+
+## Run with Docker (recommended)
+
+### 1) Create env
+```bash
+cp .env.example .env
+```
+
+### 2) Start services
+```bash
+docker compose up --build
+```
+
+**Expected**
+- app listens on `APP_PORT`
+- postgres is available via `DATABASE_URL`
+
+---
+
+## Database migrations (golang-migrate)
+
+- Migrations live in `migrations/` and must be applied before using the API.
+- **Important:** `urls.short_code` must have a **unique index**; do not rely only on application logic.
+
+### Recommended approach: Make targets (to be added)
+
+```bash
+make migrate-up
+make migrate-down
+make migrate-status
+```
+
+### Example (conceptual)
+
+> Exact command depends on how you wire `migrate` into the project.
+
+```bash
+migrate -path ./migrations -database "$DATABASE_URL" up
+```
+
+---
+
+## Run without Docker (optional)
+
+If you want to run directly on your machine:
+
+1) Start Postgres locally (or keep docker db only)
+2) Set env vars (or use `.env`)
+3) Run:
+
+```bash
+go run ./cmd/server
+```
+
+---
+
+## Tests
+
+### Unit tests
+```bash
+go test ./...
+```
+
+### Integration tests (recommended)
+
+We aim to have at least one E2E flow:
+
+- register → login → shorten → redirect → verify `click_count`
+- admin endpoint access → `403` for normal user
+
+Integration tests may require a running Postgres instance.
+
+---
+
+## Formatting & static checks
+
+### gofmt
+```bash
+gofmt -w .
+```
+
+---
+
+## CI
+
+CI runs:
+
+- `gofmt` check
+- `go test ./...`
+
+Workflow: `.github/workflows/ci.yml`
+
+---
+
+## Troubleshooting
+
+### 1) “connection refused” to DB
+- Ensure `docker compose up` is running
+- Check `DATABASE_URL` host:
+    - inside docker network it is usually `db`
+    - outside docker it is usually `localhost`
+
+### 2) Migrations fail
+- Confirm `DATABASE_URL` is correct
+- Confirm migrations are in correct order and named properly
+- Ensure the DB is clean or use down/reset carefully
+
+### 3) 401 Unauthorized
+- Ensure `Authorization: Bearer <token>` header is set
+- Ensure token is not expired
+- Ensure `JWT_SECRET` matches what the server uses
+
+### 4) Redirect returns 404
+- `shortCode` not found **OR** URL disabled
+- confirm the record exists in DB and `is_disabled=false`
+
+---
+
+## Operational notes (MVP)
+
+- Redirect uses **302** (see ADR-0007)
+- Logging is structured JSON (zerolog) with `request_id` (see ADR-0008)
+- Passwords use Argon2id (ADR-0004)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/Reza-1988/go-url-shorten
+
+go 1.25.5


### PR DESCRIPTION
## Summary
Bootstrap repository with Docs-as-Code structure, initial ADRs, kickoff meeting notes, and a minimal CI workflow.

## What’s included
- `docs/` foundation: overview, api contract (v0.1), runbook
- ADRs for key architectural decisions (Fiber/Postgres/GORM/JWT/Argon2/redirect/logging/error-format)
- Kickoff meeting note with ADR links
- Minimal CI workflow (gofmt check + go test)
- Minimal `cmd/server/main.go` to keep CI green

## Checklist
- [x] CI passes (gofmt + go test)
- [x] Docs are linked and consistent
- [x] ADRs added for key decisions
