### PR TITLE
feat(core): base62 short code generator

### DIFF
--- a/internal/shortener/codegen.go
+++ b/internal/shortener/codegen.go
@@ -1,0 +1,35 @@
+package shortener
+
+import (
+	"crypto/rand"
+	"math/big"
+)
+
+// base62Alphabet is the allowed characters for short codes (0-9, A-Z, a-z).
+const base62Alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
+
+// RandomBase62 generates a random Base62 string of the given length.
+// It uses crypto/rand, so it is safe for tokens and short links.
+func RandomBase62(length int) (string, error) {
+	// For invalid length, return an empty string (no error).
+	if length <= 0 {
+		return "", nil
+	}
+
+	// max is the upper bound for random numbers: [0, len(alphabet)).
+	max := big.NewInt(int64(len(base62Alphabet)))
+
+	// Pre-allocate the output bytes for speed and simplicity.
+	out := make([]byte, length)
+
+	for i := 0; i < length; i++ {
+		// Pick a secure random index into the alphabet.
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", err
+		}
+		out[i] = base62Alphabet[n.Int64()]
+	}
+
+	return string(out), nil
+}

--- a/internal/shortener/codegen_test.go
+++ b/internal/shortener/codegen_test.go
@@ -1,0 +1,41 @@
+package shortener
+
+import "testing"
+
+// TestRandomBase62_LengthAndCharset checks two basic rules:
+// 1) the output has the requested length
+// 2) all characters are in the Base62 alphabet
+func TestRandomBase62_LengthAndCharset(t *testing.T) {
+	const length = 7
+
+	// Run multiple times to reduce the chance of missing a random edge case.
+	for i := 0; i < 200; i++ {
+		s, err := RandomBase62(length)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Length must match exactly.
+		if len(s) != length {
+			t.Fatalf("expected length %d, got %d", length, len(s))
+		}
+
+		// Every character must be Base62.
+		for _, ch := range s {
+			if !isBase62Char(byte(ch)) {
+				t.Fatalf("unexpected char: %q in %q", ch, s)
+			}
+		}
+	}
+}
+
+// isBase62Char returns true if b exists in the Base62 alphabet.
+func isBase62Char(b byte) bool {
+	// Simple linear scan is fine here (alphabet is tiny: 62 chars).
+	for i := 0; i < len(base62Alphabet); i++ {
+		if base62Alphabet[i] == b {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
Add a secure Base62 short code generator (len=7) with unit tests.

## Notes
This supports ADR-0005 and will be used by the shorten endpoint.